### PR TITLE
Set scope=provided for opentracing-tracerresolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-tracerresolver</artifactId>
             <version>0.1.8</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.wavefront</groupId>


### PR DESCRIPTION
The scope for `opentracing-tracerresolver` should be set to provided, because the runtime that loads the WaveFront Tracer Plugin must already have the TracerResolver, otherwise this plugin would be moot.

Also, it is important to note that `opentracing-tracerresolver` imports OT API 0.33.0, while `wavefront-opentracing-sdk-java` uses OT API 0.32.0. The order of dependencies declared in the pom.xml overrides OT API 0.32.0 with OT API 0.33.0.