### PR TITLE
Set scope=provided for wavefront-opentracing-sdk-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,8 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-opentracing-sdk-java</artifactId>
-            <version>1.13</version>
+            <version>1.14</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
For #17 .  Change scope from `compile` to `provided` so that the SpecialAgent does not include multiple versions of the OT dependencies.